### PR TITLE
Added 'upload_attachment' API functionality and fixed async_std dependency paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keybase-bot-api"
-version = "0.3.0"
+version = "0.4.2"
 authors = ["Marco Munizaga <marco@marcopolo.io>"]
 edition = "2018"
 description = "Write bots for Keybase"
@@ -18,5 +18,4 @@ rand = "0.7.0"
 hex = "0.3.2"
 
 [dependencies.async-std]
-version = "1.5.0"
-features = ["unstable"]
+version = "1.10.0"


### PR DESCRIPTION
Also updated async_std to 1.10.0.

It looks like the async_std crate had moved parts of its API around, which made this crate no longer compile for me.  I updated this crate to match the async_std API and updated the dependency to the newest version.

Also, if this pull request is helpful and you have an extra minute to spare, could you please add the `hacktoberfest-accepted` label to this pull request?  More info here: https://hacktoberfest.digitalocean.com/faq .  Thank you!